### PR TITLE
Test random schedule option of ctest

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Test
         run: |
           cd $GITHUB_WORKSPACE/build
-          time ctest -I $TEST_CHUNK -j `nproc` --output-on-failure --output-junit $GITHUB_WORKSPACE/junit_test_summary.xml
+          time ctest --schedule-random -I $TEST_CHUNK -j `nproc` --output-on-failure --output-junit $GITHUB_WORKSPACE/junit_test_summary.xml
         env:
           TEST_CHUNK: ${{ matrix.test-chunk }}
       - name: Upload test summary


### PR DESCRIPTION
## Description and Context
The chunk with xfs* tests takes way longer than all others. The only obvious option of ctest that might fix this issue is the random schedule option. Thus let's give it a try.

## Related Issues and Merge Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
