### PR TITLE
Fix bug in calculation of

### DIFF
--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_standard_BGS-AMG_3x3.4C.yaml
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_standard_BGS-AMG_3x3.4C.yaml
@@ -126,139 +126,139 @@ RESULT DESCRIPTION:
       DIS: "scatra"
       NODE: 41
       QUANTITY: "phi1"
-      VALUE: 8.39939951671605023e+00
+      VALUE: 8.39937431811698332e+00
       TOLERANCE: 8.4e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 41
       QUANTITY: "phi2"
-      VALUE: -7.53188753866842758e-08
+      VALUE: -7.53188317706259399e-08
       TOLERANCE: 7.5e-16
   - SCATRA:
       DIS: "scatra"
       NODE: 41
       QUANTITY: "flux_boundary_1_x"
-      VALUE: 2.06872476223283329e-06
+      VALUE: 2.06873289806519179e-06
       TOLERANCE: 2.1e-12
   - SCATRA:
       DIS: "scatra"
       NODE: 41
       QUANTITY: "flux_boundary_1_y"
-      VALUE: -1.47349142092896882e-05
+      VALUE: -1.47349721584156462e-05
       TOLERANCE: 1.5e-11
   - SCATRA:
       DIS: "scatra"
       NODE: 41
       QUANTITY: "flux_boundary_1_z"
-      VALUE: 4.04851945963667892e-06
+      VALUE: 4.04853538155931596e-06
       TOLERANCE: 4.0e-12
   - SCATRA:
       DIS: "scatra"
       NODE: 244
       QUANTITY: "flux_boundary_1_x"
-      VALUE: -5.76293537158487625e-06
+      VALUE: -5.76294076282475405e-06
       TOLERANCE: 5.8e-12
   - SCATRA:
       DIS: "scatra"
       NODE: 244
       QUANTITY: "flux_boundary_1_y"
-      VALUE: -6.08904248873480661e-06
+      VALUE: -6.08904818504867585e-06
       TOLERANCE: 6.1e-12
   - SCATRA:
       DIS: "scatra"
       NODE: 244
       QUANTITY: "flux_boundary_1_z"
-      VALUE: 2.47375877535103840e-06
+      VALUE: 2.47376108955831258e-06
       TOLERANCE: 2.5e-12
   - SCATRA:
       DIS: "scatra"
       NODE: 244
       QUANTITY: "phi1"
-      VALUE: 1.20013211950762555e+00
+      VALUE: 1.20013345164361085e+00
       TOLERANCE: 1.2e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 244
       QUANTITY: "phi2"
-      VALUE: -9.99868324296223215e-02
+      VALUE: -9.99869658220611107e-02
       TOLERANCE: 1.0e-09
   - SCATRA:
       DIS: "scatra"
       NODE: 239
       QUANTITY: "phi1"
-      VALUE: 1.19986880160197273e+00
+      VALUE: 1.19987013436459966e+00
       TOLERANCE: 1.2e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 239
       QUANTITY: "phi2"
-      VALUE: -9.99972869096399930e-02
+      VALUE: -9.99974202633393677e-02
       TOLERANCE: 1.0e-09
   - SCATRA:
       DIS: "scatra"
       NODE: 239
       QUANTITY: "flux_boundary_1_x"
-      VALUE: -5.82976237709355550e-06
+      VALUE: -5.82974343170145335e-06
       TOLERANCE: 5.8e-12
   - SCATRA:
       DIS: "scatra"
       NODE: 239
       QUANTITY: "flux_boundary_1_y"
-      VALUE: 4.19396117004399273e-06
+      VALUE: 4.19394754063104448e-06
       TOLERANCE: 4.2e-12
   - SCATRA:
       DIS: "scatra"
       NODE: 239
       QUANTITY: "flux_boundary_1_z"
-      VALUE: -1.19551256085522954e-06
+      VALUE: -1.19550867571330365e-06
       TOLERANCE: 1.2e-12
   - SCATRA:
       DIS: "scatra"
       NODE: 390
       QUANTITY: "flux_boundary_1_x"
-      VALUE: -4.41308504048303080e-06
+      VALUE: -4.41308556916457998e-06
       TOLERANCE: 4.4e-12
   - SCATRA:
       DIS: "scatra"
       NODE: 390
       QUANTITY: "flux_boundary_1_y"
-      VALUE: 1.38895530960700717e-05
+      VALUE: 1.38895547600195268e-05
       TOLERANCE: 1.4e-11
   - SCATRA:
       DIS: "scatra"
       NODE: 390
       QUANTITY: "flux_boundary_1_z"
-      VALUE: -7.38198712814036533e-07
+      VALUE: -7.38198801249232216e-07
       TOLERANCE: 7.4e-13
   - SCATRA:
       DIS: "scatra"
       NODE: 390
       QUANTITY: "phi1"
-      VALUE: 1.27190927526898339e+01
+      VALUE: 1.27190938550572703e+01
       TOLERANCE: 1.3e-07
   - SCATRA:
       DIS: "scatra"
       NODE: 390
       QUANTITY: "phi2"
-      VALUE: 3.76629501574920367e+00
+      VALUE: 3.76629486295965821e+00
       TOLERANCE: 3.8e-08
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "soc1"
-      VALUE: 9.44444033010170325e-01
+      VALUE: 9.44443301394437662e-01
       TOLERANCE: 9.4e-09
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "soc2"
-      VALUE: 9.58384625191976203e-01
+      VALUE: 9.58384603684260705e-01
       TOLERANCE: 9.6e-09
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "cellvoltage"
-      VALUE: 3.76629418258545634e+00
+      VALUE: 3.76629402979583849e+00
       TOLERANCE: 3.8e-08
   - SCATRA:
       DIS: "scatra"

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_standard_redist_BGS-AMG_3x3.4C.yaml
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_standard_redist_BGS-AMG_3x3.4C.yaml
@@ -124,139 +124,139 @@ RESULT DESCRIPTION:
       DIS: "scatra"
       NODE: 41
       QUANTITY: "phi1"
-      VALUE: 8.39941429126984218e+00
+      VALUE: 8.39995096709273348e+00
       TOLERANCE: 8.4e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 41
       QUANTITY: "phi2"
-      VALUE: -7.53172404664942197e-08
+      VALUE: -7.54286335962877547e-08
       TOLERANCE: 7.5e-16
   - SCATRA:
       DIS: "scatra"
       NODE: 41
       QUANTITY: "flux_boundary_1_x"
-      VALUE: 2.06808466416091212e-06
+      VALUE: 2.06842228287556537e-06
       TOLERANCE: 2.1e-12
   - SCATRA:
       DIS: "scatra"
       NODE: 41
       QUANTITY: "flux_boundary_1_y"
-      VALUE: -1.47303549801706274e-05
+      VALUE: -1.47327597383514594e-05
       TOLERANCE: 1.5e-11
   - SCATRA:
       DIS: "scatra"
       NODE: 41
       QUANTITY: "flux_boundary_1_z"
-      VALUE: 4.04726677994358461e-06
+      VALUE: 4.04792750386450740e-06
       TOLERANCE: 4.0e-12
   - SCATRA:
       DIS: "scatra"
       NODE: 244
       QUANTITY: "flux_boundary_1_x"
-      VALUE: -5.76179430445600710e-06
+      VALUE: -5.76241612596914210e-06
       TOLERANCE: 5.8e-12
   - SCATRA:
       DIS: "scatra"
       NODE: 244
       QUANTITY: "flux_boundary_1_y"
-      VALUE: -6.08783685206144783e-06
+      VALUE: -6.08849386057703059e-06
       TOLERANCE: 6.1e-12
   - SCATRA:
       DIS: "scatra"
       NODE: 244
       QUANTITY: "flux_boundary_1_z"
-      VALUE: 2.47326896857006649e-06
+      VALUE: 2.47353588747955232e-06
       TOLERANCE: 2.5e-12
   - SCATRA:
       DIS: "scatra"
       NODE: 244
       QUANTITY: "phi1"
-      VALUE: 1.20005256213574363e+00
+      VALUE: 1.20008172771786503e+00
       TOLERANCE: 1.2e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 244
       QUANTITY: "phi2"
-      VALUE: -9.99865863646025171e-02
+      VALUE: -9.99838406955488451e-02
       TOLERANCE: 1.0e-09
   - SCATRA:
       DIS: "scatra"
       NODE: 239
       QUANTITY: "phi1"
-      VALUE: 1.19978922974533520e+00
+      VALUE: 1.19981842721080767e+00
       TOLERANCE: 1.2e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 239
       QUANTITY: "phi2"
-      VALUE: -9.99970421047223779e-02
+      VALUE: -9.99942951723929718e-02
       TOLERANCE: 1.0e-09
   - SCATRA:
       DIS: "scatra"
       NODE: 239
       QUANTITY: "flux_boundary_1_x"
-      VALUE: -5.82711420832406163e-06
+      VALUE: -5.82981190111837576e-06
       TOLERANCE: 5.8e-12
   - SCATRA:
       DIS: "scatra"
       NODE: 239
       QUANTITY: "flux_boundary_1_y"
-      VALUE: 4.19205606375104678e-06
+      VALUE: 4.19399679788328439e-06
       TOLERANCE: 4.2e-12
   - SCATRA:
       DIS: "scatra"
       NODE: 239
       QUANTITY: "flux_boundary_1_z"
-      VALUE: -1.19496949943652838e-06
+      VALUE: -1.19552271677410008e-06
       TOLERANCE: 1.2e-12
   - SCATRA:
       DIS: "scatra"
       NODE: 390
       QUANTITY: "flux_boundary_1_x"
-      VALUE: -4.41334408563516152e-06
+      VALUE: -4.41308280988106837e-06
       TOLERANCE: 4.4e-12
   - SCATRA:
       DIS: "scatra"
       NODE: 390
       QUANTITY: "flux_boundary_1_y"
-      VALUE: 1.38903684035843831e-05
+      VALUE: 1.38895460755698763e-05
       TOLERANCE: 1.4e-11
   - SCATRA:
       DIS: "scatra"
       NODE: 390
       QUANTITY: "flux_boundary_1_z"
-      VALUE: -7.38242044586732974e-07
+      VALUE: -7.38198339690137553e-07
       TOLERANCE: 7.4e-13
   - SCATRA:
       DIS: "scatra"
       NODE: 390
       QUANTITY: "phi1"
-      VALUE: 1.27198920524250543e+01
+      VALUE: 1.27190912930228919e+01
       TOLERANCE: 1.3e-07
   - SCATRA:
       DIS: "scatra"
       NODE: 390
       QUANTITY: "phi2"
-      VALUE: 3.76626144096189641e+00
+      VALUE: 3.76629806199253814e+00
       TOLERANCE: 3.8e-08
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "soc1"
-      VALUE: 9.44444817527186564e-01
+      VALUE: 9.44457683837476969e-01
       TOLERANCE: 9.4e-09
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "soc2"
-      VALUE: 9.58372690973991692e-01
+      VALUE: 9.58384659292510155e-01
       TOLERANCE: 9.6e-09
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "cellvoltage"
-      VALUE: 3.76626060782563554e+00
+      VALUE: 3.76629722882880236e+00
       TOLERANCE: 3.8e-08
   - SCATRA:
       DIS: "scatra"

--- a/tests/input_files/ssi_mono_3D_tet4_elch_s2i_butlervolmer_manifold_BGS-AMG_6x6.4C.yaml
+++ b/tests/input_files/ssi_mono_3D_tet4_elch_s2i_butlervolmer_manifold_BGS-AMG_6x6.4C.yaml
@@ -241,13 +241,13 @@ RESULT DESCRIPTION:
       DIS: "scatra"
       NODE: 10
       QUANTITY: "phi1"
-      VALUE: 1.03665291092284306e+01
+      VALUE: 1.03665205431324647e+01
       TOLERANCE: 1.0e-07
   - SCATRA:
       DIS: "scatra"
       NODE: 10
       QUANTITY: "phi2"
-      VALUE: -7.57871997353588293e-09
+      VALUE: -7.57876495984511681e-09
       TOLERANCE: 1.0e-16
   - SCATRA:
       DIS: "scatra"
@@ -259,7 +259,7 @@ RESULT DESCRIPTION:
       DIS: "scatra"
       NODE: 140
       QUANTITY: "phi2"
-      VALUE: -8.58128796268018412e-02
+      VALUE: -8.58129601904073225e-02
       TOLERANCE: 8.6e-10
   - SCATRA:
       DIS: "scatra"
@@ -271,119 +271,119 @@ RESULT DESCRIPTION:
       DIS: "scatra"
       NODE: 160
       QUANTITY: "phi2"
-      VALUE: -8.58125681868843748e-02
+      VALUE: -8.58126487585977177e-02
       TOLERANCE: 8.6e-10
   - SCATRA:
       DIS: "scatra"
       NODE: 200
       QUANTITY: "phi1"
-      VALUE: 1.10843087403835678e+01
+      VALUE: 1.10842911493693226e+01
       TOLERANCE: 1.1e-07
   - SCATRA:
       DIS: "scatra"
       NODE: 200
       QUANTITY: "phi2"
-      VALUE: 3.85931994069460016e+00
+      VALUE: 3.85931985282860168e+00
       TOLERANCE: 3.9e-08
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "soc1"
-      VALUE: 9.79159662749027881e-01
+      VALUE: 9.79159190301871263e-01
       TOLERANCE: 9.8e-09
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "soc2"
-      VALUE: 9.84332251016802551e-01
+      VALUE: 9.84332244632333708e-01
       TOLERANCE: 9.8e-09
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "c-rate1"
-      VALUE: -1.91872152591180134e+00
+      VALUE: -1.92153436025849067e+00
       TOLERANCE: 1.9e-06
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "c-rate2"
-      VALUE: -1.49531096631344979e-01
+      VALUE: -1.50663499803935896e-01
       TOLERANCE: 1.5e-07
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "cellvoltage"
-      VALUE: 3.85931985915460674e+00
+      VALUE: 3.85931977128313264e+00
       TOLERANCE: 3.9e-08
   - STRUCTURE:
       DIS: "structure"
       NODE: 140
       QUANTITY: "dispx"
-      VALUE: -2.18440782063646593e-05
+      VALUE: -2.18440819224949511e-05
       TOLERANCE: 2.2e-13
   - STRUCTURE:
       DIS: "structure"
       NODE: 160
       QUANTITY: "dispx"
-      VALUE: -2.28909250370554948e-06
+      VALUE: -2.28908111884392194e-06
       TOLERANCE: 2.3e-14
   - SCATRA:
       DIS: "scatra_manifold"
       NODE: 26
       QUANTITY: "phi1"
-      VALUE: 1.49512889524146830e+00
+      VALUE: 1.49512858777005797e+00
       TOLERANCE: 1.5e-08
   - SCATRA:
       DIS: "scatra_manifold"
       NODE: 26
       QUANTITY: "phi2"
-      VALUE: -4.29063170069250224e-02
+      VALUE: -4.29063572980677502e-02
       TOLERANCE: 4.3e-10
   - SCATRA:
       DIS: "scatra_manifold"
       NODE: 45
       QUANTITY: "phi1"
-      VALUE: 1.50780803426983989e+00
+      VALUE: 1.50780676035710637e+00
       TOLERANCE: 1.5e-08
   - SCATRA:
       DIS: "scatra_manifold"
       NODE: 45
       QUANTITY: "phi2"
-      VALUE: -4.29063170069288319e-02
+      VALUE: -4.29063572980715596e-02
       TOLERANCE: 4.3e-10
   - SCATRA:
       DIS: "scatra_manifold"
       NODE: 190
       QUANTITY: "phi1"
-      VALUE: 3.00308378037126067e+00
+      VALUE: 3.00308428753742351e+00
       TOLERANCE: 3.0e-08
   - SCATRA:
       DIS: "scatra_manifold"
       NODE: 190
       QUANTITY: "phi2"
-      VALUE: 1.88675355456285110e+00
+      VALUE: 1.88675346878627592e+00
       TOLERANCE: 1.9e-08
   - SCATRA:
       DIS: "scatra_manifold"
       NODE: 208
       QUANTITY: "phi1"
-      VALUE: 3.00571379827938889e+00
+      VALUE: 3.00571480215927034e+00
       TOLERANCE: 3.0e-08
   - SCATRA:
       DIS: "scatra_manifold"
       NODE: 208
       QUANTITY: "phi2"
-      VALUE: 1.88675355456287219e+00
+      VALUE: 1.88675346878629990e+00
       TOLERANCE: 1.9e-08
   - SSI:
       SPECIAL: true
       QUANTITY: "numiterlastlinearsolve"
-      VALUE: 5
+      VALUE: 6
       TOLERANCE: 1.0e-16
   - SSI:
       SPECIAL: true
       QUANTITY: "numiterlastnonlinearsolve"
-      VALUE: 6
+      VALUE: 7
       TOLERANCE: 1.0e-16
 DESIGN SURF TRANSPORT NEUMANN CONDITIONS:
   - E: 6

--- a/tests/input_files/sti_mono_3D_tet4_hex8_elch_s2i_butlervolmerpeltier_adiabatic_condensed_mortar_standard_BGS-AMG_4x4.4C.yaml
+++ b/tests/input_files/sti_mono_3D_tet4_hex8_elch_s2i_butlervolmerpeltier_adiabatic_condensed_mortar_standard_BGS-AMG_4x4.4C.yaml
@@ -182,25 +182,25 @@ RESULT DESCRIPTION:
       DIS: "scatra"
       NODE: 366
       QUANTITY: "phi1"
-      VALUE: 1.58019412195883042e+01
+      VALUE: 1.58019385862721702e+01
       TOLERANCE: 1.6e-07
   - SCATRA:
       DIS: "scatra"
       NODE: 366
       QUANTITY: "phi2"
-      VALUE: 1.18996874262692256e-02
+      VALUE: 1.18996874263001835e-02
       TOLERANCE: 1.2e-10
   - SCATRA:
       DIS: "thermo"
       NODE: 366
       QUANTITY: "phi"
-      VALUE: 3.00065724592791923e+02
+      VALUE: 3.00065724006618154e+02
       TOLERANCE: 3.0e-06
   - SCATRA:
       DIS: "scatra"
       NODE: 366
       QUANTITY: "flux_boundary_1_x"
-      VALUE: 1.41175569699038039e-05
+      VALUE: 1.41175608305675948e-05
       TOLERANCE: 1.4e-11
   - SCATRA:
       DIS: "scatra"
@@ -218,55 +218,55 @@ RESULT DESCRIPTION:
       DIS: "scatra"
       NODE: 200
       QUANTITY: "flux_boundary_1_x"
-      VALUE: 6.18614294659807269e-06
+      VALUE: 6.18613924545311086e-06
       TOLERANCE: 6.2e-12
   - SCATRA:
       DIS: "scatra"
       NODE: 200
       QUANTITY: "flux_boundary_1_y"
-      VALUE: -3.09307147329903634e-06
+      VALUE: -3.09306962272655543e-06
       TOLERANCE: 3.1e-12
   - SCATRA:
       DIS: "scatra"
       NODE: 200
       QUANTITY: "flux_boundary_1_z"
-      VALUE: -3.09307147329903634e-06
+      VALUE: -3.09306962272655543e-06
       TOLERANCE: 3.1e-12
   - SCATRA:
       DIS: "scatra"
       NODE: 200
       QUANTITY: "phi1"
-      VALUE: 1.00483563826037070e+00
+      VALUE: 1.00483563558352174e+00
       TOLERANCE: 1.0e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 200
       QUANTITY: "phi2"
-      VALUE: -2.74776654130745535e-01
+      VALUE: -2.74776729194386449e-01
       TOLERANCE: 2.7e-09
   - SCATRA:
       DIS: "thermo"
       NODE: 200
       QUANTITY: "phi"
-      VALUE: 3.00065724729514727e+02
+      VALUE: 3.00065724143341640e+02
       TOLERANCE: 3.0e-06
   - SCATRA:
       DIS: "scatra"
       NODE: 100
       QUANTITY: "phi1"
-      VALUE: 9.94945402127352829e-01
+      VALUE: 9.94945400102961730e-01
       TOLERANCE: 9.9e-09
   - SCATRA:
       DIS: "scatra"
       NODE: 100
       QUANTITY: "phi2"
-      VALUE: -2.75666524704842875e-01
+      VALUE: -2.75666599809053947e-01
       TOLERANCE: 2.8e-09
   - SCATRA:
       DIS: "thermo"
       NODE: 100
       QUANTITY: "phi"
-      VALUE: 3.00065711154183646e+02
+      VALUE: 3.00065710567949395e+02
       TOLERANCE: 3.0e-06
   - SCATRA:
       DIS: "scatra"
@@ -278,7 +278,7 @@ RESULT DESCRIPTION:
       DIS: "scatra"
       NODE: 100
       QUANTITY: "flux_boundary_1_y"
-      VALUE: 1.15529254554576753e-05
+      VALUE: 1.15529256981184590e-05
       TOLERANCE: 1.2e-11
   - SCATRA:
       DIS: "scatra"
@@ -290,7 +290,7 @@ RESULT DESCRIPTION:
       DIS: "scatra"
       NODE: 600
       QUANTITY: "flux_boundary_1_x"
-      VALUE: 1.16333314230758614e-05
+      VALUE: 1.16333312268595712e-05
       TOLERANCE: 1.2e-11
   - SCATRA:
       DIS: "scatra"
@@ -308,37 +308,37 @@ RESULT DESCRIPTION:
       DIS: "scatra"
       NODE: 600
       QUANTITY: "phi1"
-      VALUE: 8.47066506959413879e+00
+      VALUE: 8.47066537534667496e+00
       TOLERANCE: 8.5e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 600
       QUANTITY: "phi2"
-      VALUE: 3.81527623853818199e+00
+      VALUE: 3.81527616368296307e+00
       TOLERANCE: 3.8e-08
   - SCATRA:
       DIS: "thermo"
       NODE: 600
       QUANTITY: "phi"
-      VALUE: 3.00065713378790804e+02
+      VALUE: 3.00065712792572469e+02
       TOLERANCE: 3.0e-06
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "soc1"
-      VALUE: 6.44625466928755775e-01
+      VALUE: 6.44625421858256664e-01
       TOLERANCE: 6.4e-09
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "soc2"
-      VALUE: 6.45498699412143440e-01
+      VALUE: 6.45498693024567971e-01
       TOLERANCE: 6.5e-09
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "cellvoltage"
-      VALUE: 3.80342117715288186e+00
+      VALUE: 3.80342110229997443e+00
       TOLERANCE: 3.8e-08
   - STI:
       SPECIAL: true

--- a/tests/input_files/sti_mono_3D_tet4_hex8_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard_BGS-AMG_4x4.4C.yaml
+++ b/tests/input_files/sti_mono_3D_tet4_hex8_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard_BGS-AMG_4x4.4C.yaml
@@ -181,25 +181,25 @@ RESULT DESCRIPTION:
       DIS: "scatra"
       NODE: 366
       QUANTITY: "phi1"
-      VALUE: 1.58019255878967879e+01
+      VALUE: 1.58019266764187165e+01
       TOLERANCE: 1.6e-06
   - SCATRA:
       DIS: "scatra"
       NODE: 366
       QUANTITY: "phi2"
-      VALUE: 1.18996874338835254e-02
+      VALUE: 1.18996874322710774e-02
       TOLERANCE: 1.2e-09
   - SCATRA:
       DIS: "thermo"
       NODE: 366
       QUANTITY: "phi"
-      VALUE: 3.00065710402434547e+02
+      VALUE: 3.00065710610211909e+02
       TOLERANCE: 3.0e-05
   - SCATRA:
       DIS: "scatra"
       NODE: 366
       QUANTITY: "flux_boundary_1_x"
-      VALUE: 1.41172316785195226e-05
+      VALUE: 1.41173059618243429e-05
       TOLERANCE: 1.4e-10
   - SCATRA:
       DIS: "scatra"
@@ -217,7 +217,7 @@ RESULT DESCRIPTION:
       DIS: "thermo"
       NODE: 366
       QUANTITY: "flux_boundary_1_x"
-      VALUE: 4.40461224206660007e-01
+      VALUE: 4.40473598379123532e-01
       TOLERANCE: 4.4e-06
   - SCATRA:
       DIS: "thermo"
@@ -235,73 +235,73 @@ RESULT DESCRIPTION:
       DIS: "scatra"
       NODE: 200
       QUANTITY: "flux_boundary_1_x"
-      VALUE: 6.18596515455146266e-06
+      VALUE: 6.18600000453730620e-06
       TOLERANCE: 6.2e-11
   - SCATRA:
       DIS: "scatra"
       NODE: 200
       QUANTITY: "flux_boundary_1_y"
-      VALUE: -3.09298257727573133e-06
+      VALUE: -3.09300000226865310e-06
       TOLERANCE: 3.1e-11
   - SCATRA:
       DIS: "scatra"
       NODE: 200
       QUANTITY: "flux_boundary_1_z"
-      VALUE: -3.09298257727573133e-06
+      VALUE: -3.09300000226865310e-06
       TOLERANCE: 3.1e-11
   - SCATRA:
       DIS: "thermo"
       NODE: 200
       QUANTITY: "flux_boundary_1_x"
-      VALUE: 1.01326578535930772e-01
+      VALUE: 1.01327454256983501e-01
       TOLERANCE: 1.0e-06
   - SCATRA:
       DIS: "thermo"
       NODE: 200
       QUANTITY: "flux_boundary_1_y"
-      VALUE: -5.06632892679653862e-02
+      VALUE: -5.06637271284917506e-02
       TOLERANCE: 5.1e-07
   - SCATRA:
       DIS: "thermo"
       NODE: 200
       QUANTITY: "flux_boundary_1_z"
-      VALUE: -5.06632892679653862e-02
+      VALUE: -5.06637271284917506e-02
       TOLERANCE: 5.1e-07
   - SCATRA:
       DIS: "scatra"
       NODE: 200
       QUANTITY: "phi1"
-      VALUE: 1.00483555710040595e+00
+      VALUE: 1.00483557370163279e+00
       TOLERANCE: 1.0e-07
   - SCATRA:
       DIS: "scatra"
       NODE: 200
       QUANTITY: "phi2"
-      VALUE: -2.74775791207562181e-01
+      VALUE: -2.74776040213509543e-01
       TOLERANCE: 2.7e-08
   - SCATRA:
       DIS: "thermo"
       NODE: 200
       QUANTITY: "phi"
-      VALUE: 3.00065710539106647e+02
+      VALUE: 3.00065710746901800e+02
       TOLERANCE: 3.0e-05
   - SCATRA:
       DIS: "scatra"
       NODE: 100
       QUANTITY: "phi1"
-      VALUE: 9.94945457426077429e-01
+      VALUE: 9.94945420581437978e-01
       TOLERANCE: 9.9e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 100
       QUANTITY: "phi2"
-      VALUE: -2.75665589436134839e-01
+      VALUE: -2.75665845153764244e-01
       TOLERANCE: 2.8e-08
   - SCATRA:
       DIS: "thermo"
       NODE: 100
       QUANTITY: "phi"
-      VALUE: 3.00065696962579636e+02
+      VALUE: 3.00065697170387409e+02
       TOLERANCE: 3.0e-05
   - SCATRA:
       DIS: "scatra"
@@ -313,7 +313,7 @@ RESULT DESCRIPTION:
       DIS: "scatra"
       NODE: 100
       QUANTITY: "flux_boundary_1_y"
-      VALUE: 1.15523417425728021e-05
+      VALUE: 1.15524156462262289e-05
       TOLERANCE: 1.2e-10
   - SCATRA:
       DIS: "scatra"
@@ -331,7 +331,7 @@ RESULT DESCRIPTION:
       DIS: "thermo"
       NODE: 100
       QUANTITY: "flux_boundary_1_y"
-      VALUE: 9.29328590953532874e-02
+      VALUE: 9.29330855450954257e-02
       TOLERANCE: 9.3e-07
   - SCATRA:
       DIS: "thermo"
@@ -343,7 +343,7 @@ RESULT DESCRIPTION:
       DIS: "scatra"
       NODE: 600
       QUANTITY: "flux_boundary_1_x"
-      VALUE: 1.16333145746263324e-05
+      VALUE: 1.16333240832055286e-05
       TOLERANCE: 1.2e-10
   - SCATRA:
       DIS: "scatra"
@@ -361,7 +361,7 @@ RESULT DESCRIPTION:
       DIS: "thermo"
       NODE: 600
       QUANTITY: "flux_boundary_1_x"
-      VALUE: 1.16015750278815633e+00
+      VALUE: 1.16015891203788746e+00
       TOLERANCE: 1.2e-05
   - SCATRA:
       DIS: "thermo"
@@ -379,37 +379,37 @@ RESULT DESCRIPTION:
       DIS: "scatra"
       NODE: 600
       QUANTITY: "phi1"
-      VALUE: 8.47066539038701372e+00
+      VALUE: 8.47066538722524420e+00
       TOLERANCE: 8.5e-07
   - SCATRA:
       DIS: "scatra"
       NODE: 600
       QUANTITY: "phi2"
-      VALUE: 3.81527716701939434e+00
+      VALUE: 3.81527688704575940e+00
       TOLERANCE: 3.8e-07
   - SCATRA:
       DIS: "thermo"
       NODE: 600
       QUANTITY: "phi"
-      VALUE: 3.00065699187425821e+02
+      VALUE: 3.00065699395237971e+02
       TOLERANCE: 3.0e-05
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "soc1"
-      VALUE: 6.44625201282117533e-01
+      VALUE: 6.44625219623368051e-01
       TOLERANCE: 6.4e-08
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "soc2"
-      VALUE: 6.45498693464237272e-01
+      VALUE: 6.45498693298462989e-01
       TOLERANCE: 6.5e-08
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "cellvoltage"
-      VALUE: 3.80342210049752705e+00
+      VALUE: 3.80342182128919992e+00
       TOLERANCE: 3.8e-07
   - STI:
       SPECIAL: true


### PR DESCRIPTION
number of degrees of freedom and number of dimensions for the preconditioner when a nullspace_node_map has been given. This did not work, especially in coupled problems as the dof gids might have an offset and thus no node with that gid was found leaving the default value in the variables numdf and dimns.

This is now changed. Furthermore, the default values are set to an unreasonable negative value and it is checked, if it is positive after the determination procedure.

<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
